### PR TITLE
Can use dns in the config file

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,8 +11,6 @@ check_password() {
 
 check_password
 docker-compose up -d tor
-IPADDRESS=$(docker inspect -f "{{ .NetworkSettings.Networks.tarinetwork.IPAddress }}" $(docker-compose ps -q tor))
-cat template_config.toml | sed "s/__TOR_CONTAINER_IP__/$IPADDRESS/" > data/tari/config.toml
 docker-compose up wait
 
 #Check if we have the run --create_id

--- a/template_config.toml
+++ b/template_config.toml
@@ -134,7 +134,8 @@ peer_seeds = ["8c196e72cec4e8370c5a0caecc8a6cded4f86f43b1553564f653eceb159cec6f:
 # onion v2, onion v3 and dns addresses.
 transport = "tor"
 # Address of the tor control server
-tor_control_address = "/ip4/__TOR_CONTAINER_IP__/tcp/9051"
+tor_control_address = "/dns4/tor/tcp/9051"
+#tor_control_address = "/ip4/__TOR_CONTAINER_IP__/tcp/9051"
 #tor_control_address = "/ip4/127.0.0.1/tcp/9051"
 # Authentication to use for the tor control server
 tor_control_auth = "password=mypassword" # or "password=xxxxxx"


### PR DESCRIPTION
Once https://github.com/tari-project/tari/pull/1436 goes in, we can use dns to lookup the tor host.